### PR TITLE
Add separator flag for parsing timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Options:
   -L, --limit int           Maximum number of series to display (default 16)
   -l, --location location   Time zone location (e.g., UTC, Asia/Tokyo) (default Local)
       --color string        Markup bar color [never|always|auto] (default "auto")
+  -F, --separator string    Field separator between timestamp and series (default " ")
 
 Format Examples:
   ANSIC       "Mon Jan _2 15:04:05 2006"

--- a/main_test.go
+++ b/main_test.go
@@ -53,3 +53,20 @@ func TestStringToTimeAutoDetectRFC3339(t *testing.T) {
 		t.Fatalf("unexpected time\nexpected: %v\n     got: %v", expected, got)
 	}
 }
+
+func TestParseLeadingTimeWithSeparator(t *testing.T) {
+	input := "2006-01-02T15:04:05Z,series-name,detail"
+
+	wantTime := time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)
+	wantSeries := "series-name,detail"
+
+	gotTime, gotSeries := parseLeadingTime(input, "rfc3339", ",")
+
+	if !gotTime.Equal(wantTime) {
+		t.Fatalf("unexpected time\\nexpected: %v\\n     got: %v", wantTime, gotTime)
+	}
+
+	if gotSeries != wantSeries {
+		t.Fatalf("unexpected series\\nexpected: %q\\n     got: %q", wantSeries, gotSeries)
+	}
+}


### PR DESCRIPTION
## Summary
- add a -F/--separator option to control the field delimiter between timestamps and series names
- honor the configured separator while parsing leading timestamps, defaulting to space
- document the new flag and cover parsing with a custom separator in tests

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922d13a60708326806ca6ff5cc80529)